### PR TITLE
[codex] Fix GitHub Pages SPA routing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>AJZ Storybook</title>
+    <script>
+      (function () {
+        const redirect = window.location.search.match(/[?&]p=([^&]+)/);
+
+        if (!redirect) {
+          return;
+        }
+
+        const path = decodeURIComponent(redirect[1]).replace(/~and~/g, '&');
+        const target = path + window.location.hash;
+
+        window.history.replaceState(null, '', target);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/public/404.html
+++ b/client/public/404.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>AJZ Storybook</title>
+    <script>
+      (function () {
+        var location = window.location;
+        var redirect =
+          location.protocol +
+          '//' +
+          location.hostname +
+          (location.port ? ':' + location.port : '') +
+          '/?p=' +
+          encodeURIComponent(location.pathname.slice(1) + location.search.replace(/&/g, '~and~')) +
+          location.hash;
+
+        location.replace(redirect);
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## What changed
- add a GitHub Pages `404.html` SPA fallback redirect
- update `client/index.html` to restore redirected paths before React loads

## Why it changed
- direct visits and refreshes on routes like `/intuit-tutor` were returning GitHub Pages 404s
- the site uses `BrowserRouter`, which needs fallback handling on a static host

## User impact
- direct visits to deep links should resolve correctly after deployment
- refreshing a route like `/intuit-tutor` should no longer fail on the live site

## Validation
- `npm run build`
- verified `dist/404.html` is generated